### PR TITLE
use application context to get connectivityManager

### DIFF
--- a/mediation/src/main/java/net/pubnative/mediation/utils/PubnativeDeviceUtils.java
+++ b/mediation/src/main/java/net/pubnative/mediation/utils/PubnativeDeviceUtils.java
@@ -62,6 +62,7 @@ public class PubnativeDeviceUtils {
     public static boolean isNetworkAvailable(Context context) {
 
         Log.v(TAG, "isNetworkAvailable");
+        context = context.getApplicationContext();
         boolean result;
         final ConnectivityManager connectivityManager = ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
         if (connectivityManager == null) {

--- a/mediation/src/main/java/net/pubnative/mediation/utils/PubnativeDeviceUtils.java
+++ b/mediation/src/main/java/net/pubnative/mediation/utils/PubnativeDeviceUtils.java
@@ -62,9 +62,9 @@ public class PubnativeDeviceUtils {
     public static boolean isNetworkAvailable(Context context) {
 
         Log.v(TAG, "isNetworkAvailable");
-        context = context.getApplicationContext();
         boolean result;
-        final ConnectivityManager connectivityManager = ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
+        Context appContext = context.getApplicationContext();
+        final ConnectivityManager connectivityManager = ((ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE));
         if (connectivityManager == null) {
             Log.e(TAG, "ERROR: Couldn't retrieve valid ConnectivityManager, please ensure that you added `ACCESS_NETWORK_STATE` permission to your Manifest file");
             result = false;


### PR DESCRIPTION
Related to #101 

Using application context instead of passed context