### PR TITLE
Added config request params to insights querystring

### DIFF
--- a/mediation/src/main/java/net/pubnative/mediation/config/model/PubnativeConfigModel.java
+++ b/mediation/src/main/java/net/pubnative/mediation/config/model/PubnativeConfigModel.java
@@ -32,6 +32,7 @@ public class PubnativeConfigModel {
     private static final String TAG = PubnativeConfigModel.class.getSimpleName();
     public Map<String, Object>                  globals;
     public Map<String, PubnativeNetworkModel>   networks;
+    public Map<String, String>                  request_params;
     public Map<String, PubnativePlacementModel> placements;
 
     //==============================================================================================

--- a/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkRequest.java
+++ b/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkRequest.java
@@ -359,6 +359,12 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put(TRACKING_PARAMETER_APP_TOKEN, mAppToken);
         parameters.put(TRACKING_PARAMETER_REQUEST_ID, mRequestID);
+        if(mConfig.request_params != null) {
+            for (String key : mConfig.request_params.keySet()){
+                String value = mConfig.request_params.get(key);
+                parameters.put(key, value);
+            }
+        }
         return parameters;
     }
 


### PR DESCRIPTION
Change:

This patch adds a new field `request_params` to `PubnativeConfigModel` and injects it as querystring parameter in the insights 