### PR TITLE
Flurry Text is Hidden under rating on Nexus 5

### DIFF
--- a/mediation.demo/src/main/res/layout/ad_list_cell.xml
+++ b/mediation.demo/src/main/res/layout/ad_list_cell.xml
@@ -65,7 +65,9 @@
                 android:layout_marginLeft="5dp"
                 android:layout_alignParentRight="true"
                 android:layout_marginRight="5dp"
-                android:layout_marginTop="20dp" />
+                android:layout_marginTop="20dp"
+                android:maxLines="1"
+                android:ellipsize="end"/>
 
             <RatingBar
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Changes:
* Ad title text displaying in one line
* if title text longer then layout, it will be end with "..."