### PR TITLE
Interstitial fixes

### DIFF
--- a/mediation.adaters/net/pubnative/mediation/adapter/network/YahooNetworkInterstitialAdapter.java
+++ b/mediation.adaters/net/pubnative/mediation/adapter/network/YahooNetworkInterstitialAdapter.java
@@ -28,7 +28,9 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.flurry.android.FlurryAgent;
+import com.flurry.android.ads.FlurryAdErrorType;
 import com.flurry.android.ads.FlurryAdInterstitial;
+import com.flurry.android.ads.FlurryAdInterstitialListener;
 import com.flurry.android.ads.FlurryAdTargeting;
 import com.flurry.android.ads.FlurryGender;
 
@@ -37,7 +39,8 @@ import net.pubnative.mediation.exceptions.PubnativeException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitialAdapter {
+public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitialAdapter
+        implements FlurryAdInterstitialListener {
 
     private static String TAG = YahooNetworkInterstitialAdapter.class.getSimpleName();
     private FlurryAdInterstitial mInterstitial;
@@ -65,6 +68,7 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
                 invokeLoadFail(PubnativeException.ADAPTER_MISSING_DATA);
             } else {
                 FlurryAgent.setLogEnabled(true);
+                FlurryAgent.setLogLevel(Log.VERBOSE);
                 // initialize flurry with new apiKey
                 FlurryAgent.init(context, apiKey);
                 // execute/resume session
@@ -72,6 +76,7 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
                     FlurryAgent.onStartSession(context);
                 }
                 mInterstitial = new FlurryAdInterstitial(context, adSpaceName);
+                mInterstitial.setListener(this);
                 // Add targeting
                 FlurryAdTargeting targeting = getTargeting();
                 if (targeting != null) {
@@ -88,7 +93,6 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
         if (mTargeting != null) {
             result = new FlurryAdTargeting();
             result.setAge(mTargeting.age);
-
             if (mTargeting.gender == null) {
                 result.setGender(FlurryGender.UNKNOWN);
             } else if (mTargeting.gender.equals("female")) {
@@ -98,7 +102,6 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
             } else {
                 result.setGender(FlurryGender.UNKNOWN);
             }
-
             if (mTargeting.interests != null) {
                 Map interests = new HashMap();
                 interests.put("interest", TextUtils.join(",", mTargeting.interests));
@@ -135,5 +138,64 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
         if (mInterstitial != null) {
             mInterstitial.destroy();
         }
+    }
+
+    //==============================================================================================
+    // Callabacks
+    //==============================================================================================
+    // FlurryAdInterstitialListener
+    //----------------------------------------------------------------------------------------------
+    @Override
+    public void onFetched(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onFetched");
+        invokeLoadFinish(this);
+    }
+
+    @Override
+    public void onRendered(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onRendered");
+        invokeShow();
+    }
+
+    @Override
+    public void onDisplay(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onDisplay");
+        invokeImpressionConfirmed();
+    }
+
+    @Override
+    public void onClose(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onClose");
+        invokeHide();
+    }
+
+    @Override
+    public void onAppExit(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onAppExit");
+    }
+
+    @Override
+    public void onClicked(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onClicked");
+        invokeClick();
+    }
+
+    @Override
+    public void onVideoCompleted(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onVideoCompleted");
+    }
+
+    @Override
+    public void onError(FlurryAdInterstitial flurryAdInterstitial, FlurryAdErrorType flurryAdErrorType, int i) {
+
+        Log.v(TAG, "onError: " + i);
+        invokeLoadFail(PubnativeException.ADAPTER_UNKNOWN_ERROR);
     }
 }

--- a/mediation.demo/src/main/java/net/pubnative/mediation/adapter/network/YahooNetworkInterstitialAdapter.java
+++ b/mediation.demo/src/main/java/net/pubnative/mediation/adapter/network/YahooNetworkInterstitialAdapter.java
@@ -28,7 +28,9 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.flurry.android.FlurryAgent;
+import com.flurry.android.ads.FlurryAdErrorType;
 import com.flurry.android.ads.FlurryAdInterstitial;
+import com.flurry.android.ads.FlurryAdInterstitialListener;
 import com.flurry.android.ads.FlurryAdTargeting;
 import com.flurry.android.ads.FlurryGender;
 
@@ -37,7 +39,8 @@ import net.pubnative.mediation.exceptions.PubnativeException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitialAdapter {
+public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitialAdapter
+        implements FlurryAdInterstitialListener {
 
     private static String TAG = YahooNetworkInterstitialAdapter.class.getSimpleName();
     private FlurryAdInterstitial mInterstitial;
@@ -65,6 +68,7 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
                 invokeLoadFail(PubnativeException.ADAPTER_MISSING_DATA);
             } else {
                 FlurryAgent.setLogEnabled(true);
+                FlurryAgent.setLogLevel(Log.VERBOSE);
                 // initialize flurry with new apiKey
                 FlurryAgent.init(context, apiKey);
                 // execute/resume session
@@ -72,6 +76,7 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
                     FlurryAgent.onStartSession(context);
                 }
                 mInterstitial = new FlurryAdInterstitial(context, adSpaceName);
+                mInterstitial.setListener(this);
                 // Add targeting
                 FlurryAdTargeting targeting = getTargeting();
                 if (targeting != null) {
@@ -88,7 +93,6 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
         if (mTargeting != null) {
             result = new FlurryAdTargeting();
             result.setAge(mTargeting.age);
-
             if (mTargeting.gender == null) {
                 result.setGender(FlurryGender.UNKNOWN);
             } else if (mTargeting.gender.equals("female")) {
@@ -98,7 +102,6 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
             } else {
                 result.setGender(FlurryGender.UNKNOWN);
             }
-
             if (mTargeting.interests != null) {
                 Map interests = new HashMap();
                 interests.put("interest", TextUtils.join(",", mTargeting.interests));
@@ -135,5 +138,64 @@ public class YahooNetworkInterstitialAdapter extends PubnativeNetworkInterstitia
         if (mInterstitial != null) {
             mInterstitial.destroy();
         }
+    }
+
+    //==============================================================================================
+    // Callabacks
+    //==============================================================================================
+    // FlurryAdInterstitialListener
+    //----------------------------------------------------------------------------------------------
+    @Override
+    public void onFetched(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onFetched");
+        invokeLoadFinish(this);
+    }
+
+    @Override
+    public void onRendered(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onRendered");
+        invokeShow();
+    }
+
+    @Override
+    public void onDisplay(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onDisplay");
+        invokeImpressionConfirmed();
+    }
+
+    @Override
+    public void onClose(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onClose");
+        invokeHide();
+    }
+
+    @Override
+    public void onAppExit(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onAppExit");
+    }
+
+    @Override
+    public void onClicked(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onClicked");
+        invokeClick();
+    }
+
+    @Override
+    public void onVideoCompleted(FlurryAdInterstitial flurryAdInterstitial) {
+
+        Log.v(TAG, "onVideoCompleted");
+    }
+
+    @Override
+    public void onError(FlurryAdInterstitial flurryAdInterstitial, FlurryAdErrorType flurryAdErrorType, int i) {
+
+        Log.v(TAG, "onError: " + i);
+        invokeLoadFail(PubnativeException.ADAPTER_UNKNOWN_ERROR);
     }
 }

--- a/mediation.demo/src/main/java/net/pubnative/mediation/demo/activities/MainActivity.java
+++ b/mediation.demo/src/main/java/net/pubnative/mediation/demo/activities/MainActivity.java
@@ -86,6 +86,7 @@ public class MainActivity extends Activity {
             placements.add("facebook_only");
             placements.add("pubnative_only");
             placements.add("yahoo_only");
+            placements.add("yahoo_interstitial");
             placements.add("waterfall");
             placements.add("imp_day_cap_10");
             placements.add("imp_hour_cap_10");

--- a/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkInterstitial.java
+++ b/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkInterstitial.java
@@ -305,6 +305,7 @@ public class PubnativeNetworkInterstitial extends PubnativeNetworkWaterfall
 
         Log.v(TAG, "onPubnativePlacementLoadFail");
         long responseTime = System.currentTimeMillis() - mStartTimestamp;
+        interstitial.setAdListener(this);
         mInsight.trackSuccededNetwork(mPlacement.currentPriority(), responseTime);
         invokeLoadFinish();
     }
@@ -328,23 +329,27 @@ public class PubnativeNetworkInterstitial extends PubnativeNetworkWaterfall
     public void onAdapterShow(PubnativeNetworkInterstitialAdapter interstitial) {
 
         Log.v(TAG, "onPubnativePlacementLoadFail");
+        invokeShow();
     }
 
     @Override
     public void onAdapterImpressionConfirmed(PubnativeNetworkInterstitialAdapter interstitial) {
 
         Log.v(TAG, "onPubnativePlacementLoadFail");
+        invokeImpressionConfirmed();
     }
 
     @Override
     public void onAdapterClick(PubnativeNetworkInterstitialAdapter interstitial) {
 
         Log.v(TAG, "onPubnativePlacementLoadFail");
+        invokeClick();
     }
 
     @Override
     public void onAdapterHide(PubnativeNetworkInterstitialAdapter interstitial) {
 
         Log.v(TAG, "onPubnativePlacementLoadFail");
+        invokeHide();
     }
 }

--- a/mediation/src/test/java/net/pubnative/mediation/adapter/network/PubnativeNetworkRequestAdapterTest.java
+++ b/mediation/src/test/java/net/pubnative/mediation/adapter/network/PubnativeNetworkRequestAdapterTest.java
@@ -1,0 +1,68 @@
+package net.pubnative.mediation.adapter.network;
+
+import net.pubnative.mediation.request.model.PubnativeAdModel;
+
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class PubnativeNetworkRequestAdapterTest {
+
+    @Test
+    public void invokeStart_withNullListener_pass() {
+        PubnativeNetworkRequestAdapter adapter = mock(PubnativeNetworkRequestAdapter.class);
+        doCallRealMethod().when(adapter).invokeStart();
+        adapter.invokeStart();
+    }
+
+    @Test
+    public void invokeStart_withValidListener_callbackStart() {
+        PubnativeNetworkRequestAdapter adapter = mock(PubnativeNetworkRequestAdapter.class);
+        doCallRealMethod().when(adapter).invokeStart();
+        PubnativeNetworkRequestAdapter.Listener listener = spy(PubnativeNetworkRequestAdapter.Listener.class);
+        adapter.mListener = listener;
+        adapter.invokeStart();
+        verify(listener).onPubnativeNetworkAdapterRequestStarted(eq(adapter));
+    }
+
+    @Test
+    public void invokeLoaded_withNullListener_pass() {
+        PubnativeNetworkRequestAdapter adapter = mock(PubnativeNetworkRequestAdapter.class);
+        doCallRealMethod().when(adapter).invokeLoaded(any(PubnativeAdModel.class));
+        adapter.invokeLoaded(null);
+    }
+
+    @Test
+    public void invokeLoaded_withValidListener_callbackLoaded() {
+        PubnativeNetworkRequestAdapter adapter = mock(PubnativeNetworkRequestAdapter.class);
+        doCallRealMethod().when(adapter).invokeLoaded(any(PubnativeAdModel.class));
+        PubnativeNetworkRequestAdapter.Listener listener = spy(PubnativeNetworkRequestAdapter.Listener.class);
+        PubnativeAdModel model = mock(PubnativeAdModel.class);
+        adapter.mListener = listener;
+        adapter.invokeLoaded(model);
+        verify(listener).onPubnativeNetworkAdapterRequestLoaded(eq(adapter), eq(model));
+    }
+
+    @Test
+    public void invokeFailed_withNullListener_pass() {
+        PubnativeNetworkRequestAdapter adapter = mock(PubnativeNetworkRequestAdapter.class);
+        doCallRealMethod().when(adapter).invokeFailed(any(Exception.class));
+        adapter.invokeFailed(null);
+    }
+
+    @Test
+    public void invokeFailed_withValidListener_callbackFailed() {
+        PubnativeNetworkRequestAdapter adapter = mock(PubnativeNetworkRequestAdapter.class);
+        doCallRealMethod().when(adapter).invokeFailed(any(Exception.class));
+        PubnativeNetworkRequestAdapter.Listener listener = spy(PubnativeNetworkRequestAdapter.Listener.class);
+        Exception exception = mock(Exception.class);
+        adapter.mListener = listener;
+        adapter.invokeFailed(exception);
+        verify(listener).onPubnativeNetworkAdapterRequestFailed(eq(adapter), eq(exception));
+    }
+}


### PR DESCRIPTION
This pach contains the following changes

* Adds a new placement `yahoo_interstitial` that allows us to request interstitials (yahoo doesn't serves an ad in requests types different than configured in the dashboard)
* Fixes some adapter problems for Yahoo Interstitial
* Adds interstitial callbacks listener when loaded to listen for workflow from client apps (was a bug)