### PR TITLE
Fix Insight Error

### DIFF
--- a/mediation.demo/build.gradle
+++ b/mediation.demo/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile project(':mediation')
 //    FACEBOOK
     compile 'com.android.support:recyclerview-v7:23.1.0'
-    compile 'com.facebook.android:audience-network-sdk:4.+'
+    compile 'com.facebook.android:audience-network-sdk:4.11.0'
 //    FLURRY
     compile 'com.flurry.android:analytics:6.2.0'
     compile 'com.flurry.android:ads:6.2.0'

--- a/mediation.demo/build.gradle
+++ b/mediation.demo/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile project(':mediation')
 //    FACEBOOK
     compile 'com.android.support:recyclerview-v7:23.1.0'
-    compile 'com.facebook.android:audience-network-sdk:4.11.0'
+    compile 'com.facebook.android:audience-network-sdk:4.+'
 //    FLURRY
     compile 'com.flurry.android:analytics:6.2.0'
     compile 'com.flurry.android:ads:6.2.0'

--- a/mediation/src/main/java/net/pubnative/mediation/adapter/PubnativeNetworkAdapter.java
+++ b/mediation/src/main/java/net/pubnative/mediation/adapter/PubnativeNetworkAdapter.java
@@ -141,10 +141,10 @@ public abstract class PubnativeNetworkAdapter {
             Log.e(TAG, "doRequest - context not specified, dropping the call");
         } else {
             mListener = listener;
+            invokeStart();
             if (context == null) {
                 invokeFailed(new IllegalArgumentException("PubnativeNetworkAdapter - Error: null context provided"));
             } else {
-                invokeStart();
                 startTimeout(timeoutInMillis);
                 request(context);
             }

--- a/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkRequest.java
+++ b/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkRequest.java
@@ -113,7 +113,7 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
      * @param placementID valid placementId provided by Pubnative.
      * @param listener    valid Listener to keep track of request callbacks.
      */
-    public void start(Context context, String appToken, String placementID, PubnativeNetworkRequest.Listener listener) {
+    public synchronized void start(Context context, String appToken, String placementID, PubnativeNetworkRequest.Listener listener) {
 
         Log.v(TAG, "start: -placement: " + placementID + " -appToken:" + appToken);
         if (listener == null) {
@@ -230,7 +230,7 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
         }
     }
 
-    protected synchronized void doNextNetworkRequest() {
+    protected void doNextNetworkRequest() {
 
         Log.v(TAG, "doNextNetworkRequest");
         mCurrentNetworkIndex++;
@@ -253,7 +253,6 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
                     Map<String, String> extras = new HashMap<String, String>();
                     extras.put(TRACKING_PARAMETER_REQUEST_ID, mRequestID);
                     adapter.setExtras(extras);
-                    mRequestStartTimestamp = System.currentTimeMillis();
                     adapter.doRequest(mContext, networkModel.timeout, this);
                 }
             }
@@ -430,6 +429,7 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
     public void onPubnativeNetworkAdapterRequestStarted(PubnativeNetworkAdapter adapter) {
 
         Log.v(TAG, "onAdapterRequestStarted");
+        mRequestStartTimestamp = System.currentTimeMillis();
     }
 
     @Override

--- a/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkRequest.java
+++ b/mediation/src/main/java/net/pubnative/mediation/request/PubnativeNetworkRequest.java
@@ -230,7 +230,7 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
         }
     }
 
-    protected void doNextNetworkRequest() {
+    protected synchronized void doNextNetworkRequest() {
 
         Log.v(TAG, "doNextNetworkRequest");
         mCurrentNetworkIndex++;
@@ -253,6 +253,7 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
                     Map<String, String> extras = new HashMap<String, String>();
                     extras.put(TRACKING_PARAMETER_REQUEST_ID, mRequestID);
                     adapter.setExtras(extras);
+                    mRequestStartTimestamp = System.currentTimeMillis();
                     adapter.doRequest(mContext, networkModel.timeout, this);
                 }
             }
@@ -429,7 +430,6 @@ public class PubnativeNetworkRequest implements PubnativeNetworkAdapter.Listener
     public void onPubnativeNetworkAdapterRequestStarted(PubnativeNetworkAdapter adapter) {
 
         Log.v(TAG, "onAdapterRequestStarted");
-        mRequestStartTimestamp = System.currentTimeMillis();
     }
 
     @Override

--- a/mediation/src/main/java/net/pubnative/mediation/task/PubnativeHttpTask.java
+++ b/mediation/src/main/java/net/pubnative/mediation/task/PubnativeHttpTask.java
@@ -34,6 +34,7 @@ import net.pubnative.mediation.utils.PubnativeStringUtils;
 
 import java.io.DataOutputStream;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -116,9 +117,10 @@ public class PubnativeHttpTask extends AsyncTask<String, Void, String> {
                             connection.setUseCaches(false);
                             connection.setDoInput(true);
                             connection.setDoOutput(true);
+                            connection.setRequestProperty("Content-Length", Integer.toString(mPostString.getBytes().length));
                             OutputStream connectionOutputStream = connection.getOutputStream();
-                            DataOutputStream wr = new DataOutputStream(connectionOutputStream);
-                            wr.writeUTF(mPostString);
+                            OutputStreamWriter wr = new OutputStreamWriter(connectionOutputStream, "UTF-8");
+                            wr.write(mPostString);
                             wr.flush();
                             wr.close();
                         }

--- a/mediation/src/main/java/net/pubnative/mediation/task/PubnativeHttpTask.java
+++ b/mediation/src/main/java/net/pubnative/mediation/task/PubnativeHttpTask.java
@@ -118,7 +118,7 @@ public class PubnativeHttpTask extends AsyncTask<String, Void, String> {
                             connection.setDoOutput(true);
                             OutputStream connectionOutputStream = connection.getOutputStream();
                             DataOutputStream wr = new DataOutputStream(connectionOutputStream);
-                            wr.writeBytes(mPostString);
+                            wr.writeUTF(mPostString);
                             wr.flush();
                             wr.close();
                         }


### PR DESCRIPTION
This include possible fixes of invalid response time, data truncation, and encoding error.

For encoding exception: Now UTF-8 encoding is being used to avoid symbols in string.
Data truncation: Setting content-length in header of request while sending to server in order to avoid truncation.
Response time: This was very weird behaviour, just used synchronized keyword in order to make thread safe.
