### PR TITLE
Fix facebook sdk version

### DIFF
--- a/mediation.demo/build.gradle
+++ b/mediation.demo/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile project(':mediation')
 //    FACEBOOK
     compile 'com.android.support:recyclerview-v7:23.1.0'
-    compile 'com.facebook.android:audience-network-sdk:4.+'
+    compile 'com.facebook.android:audience-network-sdk:4.11.0'
 //    FLURRY
     compile 'com.flurry.android:analytics:6.2.0'
     compile 'com.flurry.android:ads:6.2.0'


### PR DESCRIPTION
This includes specified version (4.11.0) of facebook audience network SDK rather than 4.+