### PR TITLE
added retry_error field to insight to contain the latest retry error message

### DIFF
--- a/mediation/src/main/java/net/pubnative/mediation/insights/PubnativeInsightsManager.java
+++ b/mediation/src/main/java/net/pubnative/mediation/insights/PubnativeInsightsManager.java
@@ -166,6 +166,7 @@ public class PubnativeInsightsManager {
         Log.v(TAG, "trackingFailed");
         // Add a retry
         model.dataModel.retry = model.dataModel.retry + 1;
+        model.dataModel.retry_error = message;
         enqueueInsightItem(context, INSIGHTS_FAILED_DATA, model);
         sIdle = true;
         trackNext(context);

--- a/mediation/src/main/java/net/pubnative/mediation/insights/model/PubnativeInsightDataModel.java
+++ b/mediation/src/main/java/net/pubnative/mediation/insights/model/PubnativeInsightDataModel.java
@@ -62,6 +62,7 @@ public class PubnativeInsightDataModel {
     public Boolean                            video_start;
     public Boolean                            video_complete;
     public int                                retry;
+    public String                             retry_error;
     // User info
     public Integer                            age;
     public String                             education;
@@ -237,6 +238,7 @@ public class PubnativeInsightDataModel {
 
         Log.v(TAG, "reset");
         retry = 0;
+        retry_error = null;
         network = null;
         networks = null;
         delivery_segment_ids = null;


### PR DESCRIPTION
This patch adds a `retry_error` field to the insight data so we can track down what's the reason of an insight retrial 